### PR TITLE
DEV-3466 add description rpc methods to be used in audit logs

### DIFF
--- a/com/coralogix/alerts/v1/AlertService.proto
+++ b/com/coralogix/alerts/v1/AlertService.proto
@@ -17,12 +17,21 @@ import "com/coralogix/alerts/v1/AlertNotifications.proto";
 import "com/coralogix/alerts/v1/AlertFilters.proto";
 import "com/coralogix/alerts/v1/AlertActiveWhen.proto";
 import "com/coralogix/alerts/v1/DateTime.proto";
+import "google/protobuf/descriptor.proto";
+
+message AuditLogDescription {
+  optional string description = 1;
+}
+
+extend google.protobuf.MethodOptions {
+  optional AuditLogDescription audit_log_description = 5000;
+}
 
 service AlertService {
-  rpc GetAlert(GetAlertRequest) returns (GetAlertResponse) {}
-  rpc CreateAlert(CreateAlertRequest) returns (CreateAlertResponse) {}
-  rpc UpdateAlert(UpdateAlertRequest) returns (UpdateAlertResponse) {}
-  rpc DeleteAlert(DeleteAlertRequest) returns (DeleteAlertResponse) {}  
+  rpc GetAlert(GetAlertRequest) returns (GetAlertResponse) {option (audit_log_description).description = "get alert";}
+  rpc CreateAlert(CreateAlertRequest) returns (CreateAlertResponse) {option (audit_log_description).description = "create alert";}
+  rpc UpdateAlert(UpdateAlertRequest) returns (UpdateAlertResponse) {option (audit_log_description).description = "update alert";}
+  rpc DeleteAlert(DeleteAlertRequest) returns (DeleteAlertResponse) {option (audit_log_description).description = "delete alert";}
 }
 
 message GetAlertRequest {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.4


### PR DESCRIPTION
Not sure if we want to externalize the "option" seemed better to have it all simply in one repo and duplicated.